### PR TITLE
Fix missing header file. 

### DIFF
--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -17,6 +17,7 @@ limitations under the License. */
 #include <OGRE/OgreSceneManager.h>
 #include <OGRE/OgreSceneNode.h>
 #include <OGRE/OgreTextureManager.h>
+#include <OGRE/OgreTechnique.h>
 
 #include "rviz/display_context.h"
 #include "rviz/frame_manager.h"


### PR DESCRIPTION
Getting this error on compilation added OgreTechnique header file as fix. 

src/rviz_satellite/src/aerialmap_display.cpp:347:30: error: invalid use of incomplete type 'class Ogre::Technique'      