### PR TITLE
Added option to configure the map frame.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Please refer to the respective terms of service and copyrights.
 ## Options
 
 - `Topic` is the topic of the GPS measurements.
+- `Map Frame` is the map frame rigidly attached to the world with ENU convention. 
 - `Alpha` is simply the display transparency.
 - `Draw Under` will cause the map to be displayed below all other geometry.
 - `Zoom` is the zoom level of the map. Recommended values are 16-19, as anything smaller is _very_ low resolution. 22 is the current max.

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -65,6 +65,7 @@ protected Q_SLOTS:
   void updateTileUrl();
   void updateZoom();
   void updateBlocks();
+  void updateMapFrame();
 
 protected:
   // overrides from Display
@@ -156,6 +157,7 @@ protected:
   IntProperty* blocks_property_;
   FloatProperty* alpha_property_;
   Property* draw_under_property_;
+  StringProperty* map_frame_property_;
 
   /// the alpha value of the tile's material
   float alpha_;
@@ -167,6 +169,8 @@ protected:
   int zoom_;
   /// the number of tiles loaded in each direction around the center tile
   int blocks_;
+  /// the map frame, rigidly attached to the world with ENU convention - see https://www.ros.org/reps/rep-0105.html#map
+  std::string map_frame_;
 
   // tile management
   /// whether we need to re-query and re-assemble the tiles
@@ -179,8 +183,6 @@ protected:
   boost::optional<TileId> center_tile_{ boost::none };
   /// translation of the center-tile w.r.t. the map frame
   Ogre::Vector3 t_centertile_map_{ Ogre::Vector3::ZERO };
-  /// the map frame, rigidly attached to the world with ENU convention - see https://www.ros.org/reps/rep-0105.html#map
-  std::string static const MAP_FRAME;
 
   /// buffer for tf lookups not related to fixed-frame
   std::shared_ptr<tf2_ros::Buffer const> tf_buffer_{ nullptr };


### PR DESCRIPTION
I know there have been already discussions on this topic, but the conclusion was that if there is more will, this functionality might get merged.

Our story that justifies having a configurable map frame: Our mobile robots have started as GNSS-denied Search&Rescue explorers, so we relied 100% on ICP-based SLAM. Therefore, our `map` frame has historically always been whatever ICP computes. This complies to REP 105. Now we started taking our robot friends also outside and want to fuse all possible localization sources, including GNSS. To keep backwards compatibility, we want to keep the frame name `map` to be the ICP-created frame, and we call the GNSS-fused frame `gps_odom`. Without this PR, there is no way to make this plugin compatible with our codebase (except for silly things like tf rewriting nodes etc.).

I'm open to any suggestions on how to improve or simplify the code, especially the Qt part.

Thanks for the very nice plugin!