### PR TITLE
Add UTM frame mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rviz_satellite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added support for UTM frame transforms
+* Added support for specifying a custom map frame
+
 3.0.3 (2021-01-19)
 ------------------
 * Pragmatic URI check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ find_package(catkin REQUIRED
     roscpp
     rviz
     sensor_msgs
+    tf2
+    tf2_geometry_msgs
 )
 
 catkin_package(
@@ -13,6 +15,7 @@ catkin_package(
     roscpp
     rviz
     sensor_msgs
+    tf2
 )
 
 find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Gui Network REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ catkin_package(
 find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Gui Network REQUIRED)
 set(QT_LIBRARIES Qt5::Core Qt5::Gui Qt5::Network)
 
+# Ubuntu libgeographic-dev package installs into non-standard location
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};/usr/share/cmake/geographiclib")
+find_package(GeographicLib REQUIRED)
+
 
 ## BUILD ##
 
@@ -62,6 +66,7 @@ target_link_libraries(
   ${PROJECT_NAME}
   ${QT_LIBRARIES}
   ${catkin_LIBRARIES}
+  ${GeographicLib_LIBRARIES}
 )
 
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Please refer to the respective terms of service and copyrights.
 ## Options
 
 - `Topic` is the topic of the GPS measurements.
+- `Map Frame` is the map frame rigidly attached to the world with ENU convention. 
 - `Alpha` is simply the display transparency.
 - `Draw Under` will cause the map to be displayed below all other geometry.
 - `Zoom` is the zoom level of the map. Recommended values are 16-19, as anything smaller is _very_ low resolution. 22 is the current max.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ You can edit the longitude and latitude values in `launch/demo.gps` to change th
 
 Check the Usage section below to learn how to use the position of your robot and a satellite map.
 
+See demo file `launch/demo_utm.launch` for an example of using this plugin in the `UTM frame` mode (see below).
+
 ## Usage
 
 Add an instance of `AerialMapDisplay` to your rviz config.
@@ -34,6 +36,16 @@ At present the cache does not expire automatically - you should delete the files
 
 Currently, we only support the [OpenStreetMap](http://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) convention for tile URLs.
 This e.g. implies that only raster tiles (no vector tiles) are supported.
+
+Transformation of tiles to RViz fixed frame can be done in two ways that are configured using `Map Transform Type` option:
+
+1. Specify a `Map frame`, which is an ENU-oriented frame in which your robot localizes. This mode expects that the frame
+   of the subscribed `NavSatFix` messages is consistent with the measured latitude/longitude in this map frame.
+   In this mode, the tiles go through an intermediate transform to the map frame.
+2. Specify `UTM frame` (and possibly `UTM zone`). In this mode, no map frame is required and the tiles are directly 
+   placed on their UTM positions. This mode expects UTM frame is represented in your transform tree. The subscribed
+   `NavSatFix` messages are only used to determine the tiles to download, so small inconsistencies between the
+   `NavSatFix` frame and the measured latitude/longitude is not a big problem.
 
 ## Tile servers
 
@@ -55,7 +67,11 @@ Please refer to the respective terms of service and copyrights.
 ## Options
 
 - `Topic` is the topic of the GPS measurements.
+- `Map Transform Type` selects between the `Map frame` mode and `UTM frame` mode (see section `Usage`).
 - `Map Frame` is the map frame rigidly attached to the world with ENU convention. 
+- `UTM Frame` is the frame that represents UTM coordinate frame.
+- `UTM Zone` is the zone used by the `UTM frame`. Value `-1` triggers autodetection of zone and this property is then
+  overridden with the autodetected zone.
 - `Alpha` is simply the display transparency.
 - `Draw Under` will cause the map to be displayed below all other geometry.
 - `Zoom` is the zoom level of the map. Recommended values are 16-19, as anything smaller is _very_ low resolution. 22 is the current max.

--- a/launch/demo_utm.launch
+++ b/launch/demo_utm.launch
@@ -1,0 +1,12 @@
+<launch>
+    <!-- Send a static GPS fix to every new subscriber. Edit latitude and longitude in launch/demo.gps to use your own position. -->
+    <node pkg="rostopic" type="rostopic" name="fake_gps_fix" args="pub /gps/fix sensor_msgs/NavSatFix --latch --file=$(find rviz_satellite)/launch/demo.gps" />
+
+    <!-- Start rviz with a pre-configured AerialMap instance. It will use the fake GPS fix from above. -->
+    <node pkg="rviz" type="rviz" name="rviz" args="-d $(find rviz_satellite)/launch/demo_utm.rviz"/>
+
+    <!-- Static fake TF transform -->
+    <node pkg="tf2_ros" type="static_transform_publisher" name="static_tf_fake" args="100 200 5 0.3 0 0 map base_link" />
+    <!-- UTM transform of the map frame -->
+    <node pkg="tf2_ros" type="static_transform_publisher" name="static_tf_fake_utm" args="483676.073 4422149.429 -35.551 0 0 0 utm map" />
+</launch>

--- a/launch/demo_utm.rviz
+++ b/launch/demo_utm.rviz
@@ -46,7 +46,7 @@ Visualization Manager:
       Object URI: https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
       Topic: /gps/fix
       Value: true
-      Map transform type: Via UTM frame
+      Map transform type: Explicit UTM Frame
       Zoom: 18
     - Class: rviz/TF
       Enabled: true

--- a/launch/demo_utm.rviz
+++ b/launch/demo_utm.rviz
@@ -1,0 +1,136 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /AerialMapDisplay1
+        - /TF1
+        - /TF1/Tree1
+      Splitter Ratio: 0.5
+    Tree Height: 787
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 1
+      Blocks: 3
+      Class: rviz_plugins/AerialMapDisplay
+      Draw Behind: false
+      Enabled: true
+      Name: AerialMapDisplay
+      Object URI: https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
+      Topic: /gps/fix
+      Value: true
+      Map transform type: Via UTM frame
+      Zoom: 18
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base_link:
+          Value: true
+        map:
+          Value: true
+      Marker Scale: 200
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        map:
+          base_link:
+            {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 602.28759765625
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 106.2084732055664
+        Y: 175.504150390625
+        Z: -3.3551697731018066
+      Focal Shape Fixed Size: false
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.6347975730895996
+      Target Frame: map
+      Value: Orbit (rviz)
+      Yaw: 4.8935699462890625
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1016
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001910000039efc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000039e000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c0000026100000001000001100000039efc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d0000039e000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073d0000004cfc0100000002fb0000000800540069006d006500000000000000073d000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004900000039e00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1853
+  X: 67
+  Y: 27

--- a/package.xml
+++ b/package.xml
@@ -19,11 +19,14 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rviz</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
 
   <run_depend>geographiclib</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>tf2</run_depend>
   <run_depend>tf2_ros</run_depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -14,11 +14,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>geographiclib</build_depend>
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rviz</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
+  <run_depend>geographiclib</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>sensor_msgs</run_depend>

--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -34,6 +34,7 @@ limitations under the License. */
 #include "mercator.h"
 
 #include <regex>
+#include <unordered_map>
 
 
 namespace rviz
@@ -50,6 +51,12 @@ namespace rviz
  * Splitting this transform lookup is necessary to mitigate frame jitter.
  */
 
+std::unordered_map<MapTransformType, QString> mapTransformTypeStrings =
+{
+  {MapTransformType::VIA_MAP_FRAME, "NavSatFix Messages and Map Frame"},
+  {MapTransformType::VIA_UTM_FRAME, "Explicit UTM Frame"},
+};
+
 AerialMapDisplay::AerialMapDisplay() : Display()
 {
   topic_property_ =
@@ -57,11 +64,13 @@ AerialMapDisplay::AerialMapDisplay() : Display()
                            "sensor_msgs::NavSatFix topic to subscribe to.", this, SLOT(updateTopic()));
 
   map_transform_type_property_ =
-      new EnumProperty("Map transform type", "Via map frame",
-                       "Whether to transform tiles via map frame or via UTM frame",
+      new EnumProperty("Map transform type", mapTransformTypeStrings[MapTransformType::VIA_MAP_FRAME],
+                       "Whether to transform tiles via map frame and fix messages or via UTM frame",
                        this, SLOT(updateMapTransformType()));
-  map_transform_type_property_->addOptionStd("Via map frame", static_cast<int>(MapTransformType::VIA_MAP_FRAME));
-  map_transform_type_property_->addOptionStd("Via UTM frame", static_cast<int>(MapTransformType::VIA_UTM_FRAME));
+  map_transform_type_property_->addOption(mapTransformTypeStrings[MapTransformType::VIA_MAP_FRAME],
+                                          static_cast<int>(MapTransformType::VIA_MAP_FRAME));
+  map_transform_type_property_->addOption(mapTransformTypeStrings[MapTransformType::VIA_UTM_FRAME],
+                                          static_cast<int>(MapTransformType::VIA_UTM_FRAME));
   map_transform_type_property_->setShouldBeSaved(true);
   map_transform_type_ = static_cast<MapTransformType>(map_transform_type_property_->getOptionInt());
   

--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -29,6 +29,7 @@ limitations under the License. */
 #include "rviz/properties/property.h"
 #include "rviz/properties/ros_topic_property.h"
 #include "rviz/properties/string_property.h"
+#include "rviz/properties/tf_frame_property.h"
 
 #include <tf2/LinearMath/Vector3.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -79,15 +80,15 @@ AerialMapDisplay::AerialMapDisplay() : Display()
   map_transform_type_property_->setShouldBeSaved(true);
   map_transform_type_ = static_cast<MapTransformType>(map_transform_type_property_->getOptionInt());
   
-  map_frame_property_ =
-      new StringProperty("Map Frame", "map", "Frame ID of the map.", this, SLOT(updateMapFrame()));
+  map_frame_property_ = new TfFrameProperty(
+      "Map Frame", "map", "Frame ID of the map.", this, nullptr, false, SLOT(updateMapFrame()));
   map_frame_property_->setShouldBeSaved(true);
-  map_frame_ = map_frame_property_->getStdString();
+  map_frame_ = map_frame_property_->getFrameStd();
   
-  utm_frame_property_ =
-      new StringProperty("UTM Frame", "utm", "Frame ID of the UTM frame.", this, SLOT(updateUtmFrame()));
+  utm_frame_property_ = new TfFrameProperty(
+      "UTM Frame", "utm", "Frame ID of the UTM frame.", this, nullptr, false, SLOT(updateUtmFrame()));
   utm_frame_property_->setShouldBeSaved(true);
-  utm_frame_ = utm_frame_property_->getStdString();
+  utm_frame_ = utm_frame_property_->getFrameStd();
   
   utm_zone_property_ =
       new IntProperty("UTM Zone", GeographicLib::UTMUPS::STANDARD, "UTM zone (-1 means autodetect).",
@@ -141,6 +142,8 @@ AerialMapDisplay::~AerialMapDisplay()
 void AerialMapDisplay::onInitialize()
 {
   tf_buffer_ = context_->getFrameManager()->getTF2BufferPtr();
+  map_frame_property_->setFrameManager(context_->getFrameManager());
+  utm_frame_property_->setFrameManager(context_->getFrameManager());
   updateMapTransformType();
 }
 
@@ -397,7 +400,7 @@ void AerialMapDisplay::updateMapFrame()
   //  - reset and update the center tile
   //  - update transforms
 
-  auto const map_frame = map_frame_property_->getStdString();
+  auto const map_frame = map_frame_property_->getFrameStd();
   if (map_frame == map_frame_)
   {
     return;
@@ -428,7 +431,7 @@ void AerialMapDisplay::updateUtmFrame()
   //  - reset and update the center tile
   //  - update transforms
 
-  auto const utm_frame = utm_frame_property_->getStdString();
+  auto const utm_frame = utm_frame_property_->getFrameStd();
   if (utm_frame == utm_frame_)
   {
     return;

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -39,12 +39,13 @@ class ManualObject;
 
 namespace rviz
 {
+class EnumProperty;
 class FloatProperty;
 class IntProperty;
 class Property;
 class RosTopicProperty;
 class StringProperty;
-class EnumProperty;
+class TfFrameProperty;
 
 /**
  * @brief Whether the tiles should be transformed via an intermediate map frame,
@@ -184,8 +185,8 @@ protected:
   FloatProperty* alpha_property_;
   Property* draw_under_property_;
   EnumProperty* map_transform_type_property_;
-  StringProperty* map_frame_property_;
-  StringProperty* utm_frame_property_;
+  TfFrameProperty* map_frame_property_;
+  TfFrameProperty* utm_frame_property_;
   IntProperty* utm_zone_property_;
 
   /// the alpha value of the tile's material

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -43,6 +43,17 @@ class IntProperty;
 class Property;
 class RosTopicProperty;
 class StringProperty;
+class EnumProperty;
+
+/**
+ * @brief Whether the tiles should be transformed via an intermediate map frame,
+ * or directly via a UTM frame.
+ */
+enum class MapTransformType
+{
+  VIA_MAP_FRAME,
+  VIA_UTM_FRAME,
+};
 
 /**
  * @brief Displays a satellite map along the XY plane.
@@ -65,12 +76,16 @@ protected Q_SLOTS:
   void updateTileUrl();
   void updateZoom();
   void updateBlocks();
+  void updateMapTransformType();
   void updateMapFrame();
+  void updateUtmFrame();
+  void updateUtmZone();
 
 protected:
   // overrides from Display
   void onEnable() override;
   void onDisable() override;
+  void onInitialize() override;
 
   virtual void subscribe();
   virtual void unsubscribe();
@@ -157,7 +172,10 @@ protected:
   IntProperty* blocks_property_;
   FloatProperty* alpha_property_;
   Property* draw_under_property_;
+  EnumProperty* map_transform_type_property_;
   StringProperty* map_frame_property_;
+  StringProperty* utm_frame_property_;
+  IntProperty* utm_zone_property_;
 
   /// the alpha value of the tile's material
   float alpha_;
@@ -169,8 +187,14 @@ protected:
   int zoom_;
   /// the number of tiles loaded in each direction around the center tile
   int blocks_;
+  /// Whether the tiles should be transformed via an intermediate map frame, or directly via a UTM frame.
+  MapTransformType map_transform_type_;
   /// the map frame, rigidly attached to the world with ENU convention - see https://www.ros.org/reps/rep-0105.html#map
   std::string map_frame_;
+  /// the utm frame, representing a UTM coordinate frame in a chosen zone
+  std::string utm_frame_;
+  /// UTM zone to work in
+  int utm_zone_;
 
   // tile management
   /// whether we need to re-query and re-assemble the tiles

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -19,6 +19,7 @@ limitations under the License. */
 
 #include <boost/optional.hpp>
 
+#include <geometry_msgs/PoseStamped.h>
 #include <ros/ros.h>
 #include <ros/time.h>
 #include <rviz/display.h>
@@ -131,6 +132,16 @@ protected:
   void createTileObjects();
 
   /**
+   * Transforms the tile objects into the reference (map/utm) frame.
+   */
+  void transformTileToReferenceFrame();
+
+  /**
+   * Transforms the tile objects into the UTM frame.
+   */
+  void transformTileToUtmFrame();
+
+  /**
    * Transforms the tile objects into the map frame.
    */
   void transformTileToMapFrame();
@@ -205,8 +216,8 @@ protected:
   TileCacheDelay<OgreTile> tile_cache_;
   /// Last request()ed tile id (which is the center tile)
   boost::optional<TileId> center_tile_{ boost::none };
-  /// translation of the center-tile w.r.t. the map frame
-  Ogre::Vector3 t_centertile_map_{ Ogre::Vector3::ZERO };
+  /// translation of the center-tile w.r.t. the map/utm frame
+  geometry_msgs::PoseStamped center_tile_pose_;
 
   /// buffer for tf lookups not related to fixed-frame
   std::shared_ptr<tf2_ros::Buffer const> tf_buffer_{ nullptr };

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -65,6 +65,7 @@ protected Q_SLOTS:
   void updateTileUrl();
   void updateZoom();
   void updateBlocks();
+  void updateMapFrame();
 
 protected:
   // overrides from Display
@@ -156,6 +157,7 @@ protected:
   IntProperty* blocks_property_;
   FloatProperty* alpha_property_;
   Property* draw_under_property_;
+  StringProperty* map_frame_property_;
 
   /// the alpha value of the tile's material
   float alpha_;
@@ -167,6 +169,8 @@ protected:
   int zoom_;
   /// the number of tiles loaded in each direction around the center tile
   int blocks_;
+  /// the map frame, rigidly attached to the world with ENU convention - see https://www.ros.org/reps/rep-0105.html#map
+  std::string map_frame_;
 
   // tile management
   /// whether we need to re-query and re-assemble the tiles
@@ -179,8 +183,6 @@ protected:
   boost::optional<TileId> center_tile_{ boost::none };
   /// translation of the center-tile w.r.t. the map frame
   Ogre::Vector3 t_centertile_map_{ Ogre::Vector3::ZERO };
-  /// the map frame, rigidly attached to the world with ENU convention - see https://www.ros.org/reps/rep-0105.html#map
-  std::string static const MAP_FRAME;
 
   /// buffer for tf lookups not related to fixed-frame
   std::shared_ptr<tf2_ros::Buffer const> tf_buffer_{ nullptr };

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -74,6 +74,21 @@ TileCoordinateGeneric<NumericType> fromWGSCoordinate(WGSCoordinate coord, int zo
   return ret;
 }
 
+/**
+ * Convert tile coordinate to lat/lon.
+ *
+ * @see https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames for explanation of these calculations.
+ */
+template <typename NumericType = int>
+WGSCoordinate toWGSCoordinate(TileCoordinateGeneric<NumericType> coord, int zoom)
+{
+  WGSCoordinate ret{ 0, 0 };
+  ret.lon = coord.x / std::pow(2.0, zoom) * 360.0 - 180;
+  double n = M_PI - 2.0 * M_PI * (1 + coord.y) / std::pow(2.0, zoom);
+  ret.lat = 180.0 / M_PI * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
+  return ret;
+}
+
 template <typename NumericType>
 bool operator==(TileCoordinateGeneric<NumericType> self, TileCoordinateGeneric<NumericType> other)
 {


### PR DESCRIPTION
Depends on #104.

I know there have already been discussions whether explicit UTM frame is something that should be supported or not. I tried to understand the conclusions, but did not succeed fully. I'll try to explain our use-case, which should hopefully be the justification for this feature.

Our mobile robots are expected to drive through any kind of environment, so we cannot rely on good GPS reception. It happens frequently that we have fix with covariances around 100 (but we often also have the good 1e-4 ones). We run odometry fusion based on robot_localization package and a factor graph approach that puts the dead-reckoning odometry and absolute GNSS measurements into a graph, which is then optimized to yield the best available absolute pose estimate.

It seems to me this setup is not compatible with the current rviz_satellite philosophy. If I understood handling of the map frame correctly, each fix message's lat/lon is transformed to map frame using its TF frame, and the tiles are positioned based on this composite latlon-TF transform. However, in our case, the fix messages do not carry precise location information - they are the noisy raw data. So the latlon information they carry is not __consistent__ with the optimized TF `gps`->`map`. When the robot (actually, the fix message) enters a new tile, the composite latlon-TF transform is evaluated and whatever is there is used to place all the tiles. This results in large inaccuracies in the tile positioning.

In our system, we explicitly model the `utm` frame in TF (robot_localization has an easy-to-configure option for it). So we publish the UTM waypoints in rviz and visualize them. This serves as the "ground truth" for evaluating whether the tiles are placed correctly. I've added a new mode to this plugin that allows to utilize this explicit `utm` frame and makes it possible to place the tiles directly in the UTM coordinates, rather than passing them through the imprecise pose estimation. The biggest benefit I see in using this mode is that I can be 100% sure the tiles are positioned correctly (up to the small jumps reported in #92 which I also see in the UTM mode, which might even be just rounding errors), so it is easier to visually evaluate our odometry estimates. And the quality of the estimates has no influence on the tile placement. The only thing I don't like is that tile selection is still done based on the fix messages and not using some TF frame (i.e. `base_link` position in UTM), but that would overcomplicate things, and as long as the fix stays at least roughly correct, it works.

The default behavior of the plugin stays as it was before (the "Via map frame" option is default).

I'm open to any suggestions on how to improve this PR. I'm not 100% sure with all the update functions. Maybe there is better wording for the newly introduced options and their documentation.