### PR TITLE
Add support for tileserver APIs taking latitude and longitude values instead of tile coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ Transformation of tiles to RViz fixed frame can be done in two ways that are con
 
 You must provide a tile URL (Object URI) from which the satellite images are loaded.
 The URL should have the form `http://server.tld/{z}/{x}/{y}.jpg`.
-Where the tokens `{z}`, `{x}`, `{y}` represent the zoom level, x coordinate, and y coordinate respectively.
-These will automatically be substituted by rviz_satellite when making HTTP requests.
+Where the tokens `{z}`, `{x}`, `{y}` represent the zoom level, x coordinate, and y coordinate respectively. If your API requires a pair of latitude and longitude values instead of x and y tile coordinates, use an URL of the form `http://server.tld/{z}/{lat}/{lon}.jpg`, where `{lat}` and `{lon}` represent the latitude and longitude values of the requested location. All these will automatically be substituted by rviz_satellite when making HTTP requests.
 
 rviz_satellite doesn't come with any preconfigured tile URL.
 For example, you could use one of the following tile servers:
@@ -62,6 +61,8 @@ For example, you could use one of the following tile servers:
 * OpenStreetMap: https://tile.openstreetmap.org/{z}/{x}/{y}.png
 * TomTom: https://api.tomtom.com/map/1/tile/basic/main/{z}/{x}/{y}.png?tileSize=512&key=[TOKEN]
 * Mapbox: https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/256/{z}/{x}/{y}?access_token=[TOKEN]
+* GoogleMaps: https://maps.googleapis.com/maps/api/staticmap?maptype=satellite&center={lat},{lon}&zoom={z}&size=256x256&key=[TOKEN]
+
 
 For some of these, you have to request an access token first.
 Please refer to the respective terms of service and copyrights.

--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -288,9 +288,9 @@ void AerialMapDisplay::updateTileUrl()
     ROS_ERROR("Invalid Object URI: %s", tile_url.c_str());
     // Still setting the url since keeping the old is probably unexpected
   }
-  else if (!std::regex_match(tile_url, std::regex(R"(.*\{[xyz]\}.*)")))
+  else if (!std::regex_match(tile_url, std::regex(R"(.*\{([xyz]|lat|lon)\}.*)")))
   {
-    ROS_ERROR("No coordinates ({x}, {y} or {z}) found in URI: %s", tile_url.c_str());
+    ROS_ERROR("No coordinates ({lat}, {lon} or {x}, {y}, {z}) found in URI: %s", tile_url.c_str());
   }
 
   tile_url_ = tile_url;

--- a/src/tile_id.cpp
+++ b/src/tile_id.cpp
@@ -37,13 +37,11 @@ std::string tileURL(TileId const& tile_id)
   auto url = tile_id.tile_server;  
 
   // compute latitude and longitude from tile coordinates
-  float n = pow(2, tile_id.zoom);
-  float lon_deg = float(tile_id.coord.x) / float(n) * 360.0f - 180.0f;
-  float lat_deg = 180.0f / M_PI * atan(sinh(M_PI * (1 - 2 * tile_id.coord.y / n)));
+  const auto wgs = toWGSCoordinate(tile_id.coord, tile_id.zoom);
 
   // substitute placeholders
-  boost::replace_all(url, "{lat}", std::to_string(lat_deg));
-  boost::replace_all(url, "{lon}", std::to_string(lon_deg));
+  boost::replace_all(url, "{lat}", toString(wgs.lat));
+  boost::replace_all(url, "{lon}", toString(wgs.lon));
   boost::replace_all(url, "{x}", std::to_string(tile_id.coord.x));
   boost::replace_all(url, "{y}", std::to_string(tile_id.coord.y));
   boost::replace_all(url, "{z}", std::to_string(tile_id.zoom));

--- a/src/tile_id.cpp
+++ b/src/tile_id.cpp
@@ -16,7 +16,22 @@ limitations under the License. */
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/functional/hash/hash.hpp>
-
+namespace
+{
+/**
+ * \brief Locale-independent conversion of doubles to strings.
+ * \param[in] num The number.
+ * \return The string.
+ */
+std::string toString(double num)
+{
+  std::stringstream ss;
+  ss.imbue(std::locale::classic());
+  ss.precision(6);
+  ss << std::fixed << num;
+  return ss.str();
+}
+}
 std::string tileURL(TileId const& tile_id)
 {
   auto url = tile_id.tile_server;  

--- a/src/tile_id.cpp
+++ b/src/tile_id.cpp
@@ -19,10 +19,20 @@ limitations under the License. */
 
 std::string tileURL(TileId const& tile_id)
 {
-  auto url = tile_id.tile_server;
+  auto url = tile_id.tile_server;  
+
+  // compute latitude and longitude from tile coordinates
+  float n = pow(2, tile_id.zoom);
+  float lon_deg = float(tile_id.coord.x) / float(n) * 360.0f - 180.0f;
+  float lat_deg = 180.0f / M_PI * atan(sinh(M_PI * (1 - 2 * tile_id.coord.y / n)));
+
+  // substitute placeholders
+  boost::replace_all(url, "{lat}", std::to_string(lat_deg));
+  boost::replace_all(url, "{lon}", std::to_string(lon_deg));
   boost::replace_all(url, "{x}", std::to_string(tile_id.coord.x));
   boost::replace_all(url, "{y}", std::to_string(tile_id.coord.y));
   boost::replace_all(url, "{z}", std::to_string(tile_id.zoom));
+  
   return url;
 }
 


### PR DESCRIPTION
Tile Servers like Googles Static Map API require a pair of latitude and longitude values instead of x-y tile coordinates. Therefore, it is now supported to use {lat} and {lon} as placeholders in the tileserver URL. These will be automatically replaced by rviz_satellite according to the center coordinate of each tile when making HTTP requests. 