### PR TITLE
Fix tile map not moving

### DIFF
--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -35,9 +35,19 @@ std::string tileURL(const TileId & tile_id)
 }
 
 /**
+ * 2D vector struct with double precision
+ * Ogre::Vector2 does not provide double but float precision
+ * which leads to numerical errors computing the tile offset
+ */
+struct Vector2Double {
+  const double x;
+  const double y;
+};
+
+/**
  * @see https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames for explanation of these calculations.
  */
-Ogre::Vector2 computeTileCoordinate(const sensor_msgs::msg::NavSatFix & point, int zoom)
+Vector2Double computeTileCoordinate(const sensor_msgs::msg::NavSatFix & point, int zoom)
 {
   if (zoom > MAX_ZOOM) {
     throw std::invalid_argument("Zoom level " + std::to_string(zoom) + " too high");
@@ -51,7 +61,7 @@ Ogre::Vector2 computeTileCoordinate(const sensor_msgs::msg::NavSatFix & point, i
   const int n = 1 << zoom;
   const double x = n * ((point.longitude + 180) / 360.0);
   const double y = n * (1 - (std::log(std::tan(lat) + 1 / std::cos(lat)) / M_PI)) / 2;
-  return Ogre::Vector2(x, y);
+  return {x, y};
 }
 
 TileCoordinate fromWGS(const sensor_msgs::msg::NavSatFix & point, int zoom)


### PR DESCRIPTION
When driving around, the tile map was being "pulled back" to a previous position. It looked like the robot was not moving relative to the map. I found a commit that fixes this. Thanks @karl-schulz.