### PR TITLE
add support for bing map url quadkey in ros1 branch

### DIFF
--- a/src/tile_id.cpp
+++ b/src/tile_id.cpp
@@ -45,6 +45,11 @@ std::string tileURL(TileId const& tile_id)
   boost::replace_all(url, "{x}", std::to_string(tile_id.coord.x));
   boost::replace_all(url, "{y}", std::to_string(tile_id.coord.y));
   boost::replace_all(url, "{z}", std::to_string(tile_id.zoom));
+
+  /* Added by Peixuan Shu to handle bing map */
+  boost::replace_all(url, "{q}", TilesToQuadkey(tile_id.coord.x, 
+                                                tile_id.coord.y,
+                                                tile_id.zoom));
   
   return url;
 }
@@ -57,4 +62,25 @@ size_t std::hash<TileId>::operator()(TileId const& tile_id) const
   boost::hash_combine(seed, tile_id.coord.y);
   boost::hash_combine(seed, tile_id.zoom);
   return seed;
+}
+
+std::string TilesToQuadkey(int x, int y, int z) 
+{
+  std::stringstream quadkey;
+  for (int i = z; i > 0; i--) {
+    char b = '0';
+    int mask = 1 << (i - 1);
+    if ((x & mask) != 0) 
+    {
+      b++;
+    }
+    if ((y & mask) != 0) 
+    {
+      b++;
+      b++;
+    }
+    quadkey << b;
+  }
+  // std::cout << "quadkey: " << std::endl;
+  return quadkey.str();
 }

--- a/src/tile_id.h
+++ b/src/tile_id.h
@@ -58,3 +58,5 @@ Q_DECLARE_METATYPE(TileId)
  * Generate the URL to download a tile from
  */
 std::string tileURL(TileId const& tile_id);
+
+std::string TilesToQuadkey(int x, int y, int z);


### PR DESCRIPTION
The bing map uses quadkey rather than tile xyz. The new commit adds  support for the bing map quadkey in ros1 branch. For example, you can use the following bing satellite map url now:

```bash
http://ecn.t3.tiles.virtualearth.net/tiles/a{q}.jpeg?g=1
```

, where `{q}` is the quadkey.