### PR TITLE
fix: time conversion constant in publish_demo_data

### DIFF
--- a/demo/publish_demo_data
+++ b/demo/publish_demo_data
@@ -6,9 +6,10 @@ import rclpy
 import math
 import numpy as np
 from argparse import ArgumentParser
-from rclpy.time import CONVERSION_CONSTANT
 from sensor_msgs.msg import NavSatFix, NavSatStatus
 
+
+CONVERSION_CONSTANT = 1e9
 
 class CircularTranslate():
     """Translate fix periodically in a circle"""


### PR DESCRIPTION
CONVERSION_CONSTANT seems not present in ros2 jazzy.
Therefore, defined the value as constant for backward compatibility.