### PR TITLE
Add libproj-dev as dependency at package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>angles</depend>
+  <depend>proj</depend>
   <depend>rclcpp</depend>
   <depend>rcpputils</depend>
   <depend>rviz_common</depend>


### PR DESCRIPTION
## Description
Add `libproj-dev` as dependency so that it will be automatically installed using `rosdep`.

## How to test
Follow these steps to download, install and test the repo.

1. Clone the repo to your workspace
```bash
cd ~/workspace/src/
git clone https://github.com/nikosmitrop1995/rviz_satellite.git -b fix/add_proj_lib
```
2. Download the dependencies
```bash
cd ~/workspace
sudo apt update
rosdep update
rosdep install --from-paths src -y --ignore-src --rosdistro $ROS_DISTRO
```
3. Compile the code
```bash
cd ~/workspace
colcon build --packages-select rviz_satellite
```
All the steps should be implemented without any error