### PR TITLE
Improve Error Handling When GPSNavFix Jumps Long Distances

### DIFF
--- a/src/aerialmap_display.hpp
+++ b/src/aerialmap_display.hpp
@@ -68,7 +68,7 @@ protected:
 
   bool validateProperties();
 
-  void shiftMap(TileCoordinate center_tile, Ogre::Vector2i offset, double size);
+  bool shiftMap(TileCoordinate center_tile, Ogre::Vector2i offset, double size);
 
   void buildMap(TileCoordinate center_tile, double size);
 


### PR DESCRIPTION
### Issue
When GPSNavFix data jumps to a far distance, the aerial map display plugin attempts to shift the map but fails to erase tiles properly, causing RViz to crash due to an assertion failure.

> [INFO] [1743926918.557415000] [rviz2]: Setting estimate pose: Frame:world, Position(-1675.68, -10.8693, 0), Orientation(0, 0, 0, 1) = Angle: 0
[INFO] [1743926922.516310233] [rviz2]: Setting estimate pose: Frame:world, Position(-2875.83, 1482.03, 0), Orientation(0, 0, 0, 1) = Angle: 0
terminate called after throwing an instance of 'rcpputils::AssertionException'
  what():  failed to erase tile at far end
[ros2run]: Aborted

### Root Cause
The code was using `rcpputils::assert_true()` to verify tile erasure during map shifting, which terminates the entire RViz process when the assertion fails. This is too aggressive for handling what should be a recoverable error.

### Solution
- Replaced the assertion with proper error handling that prevents RViz from crashing
- When a tile erasure failure is detected, the map shifting operation is aborted
- Added error logging to notify users when this occurs
- The map will be rebuilt from scratch on the next update instead of trying to shift

### Testing
Tested with GPS data containing long-distance jumps. RViz now continues operating properly and rebuilds the map instead of crashing.

This change improves overall stability when dealing with unstable or rapidly changing GPS data.