### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,16 @@ target_compile_options(
   "-DRVIZ_SATELLITE_VERSION=\"${rviz_satellite_VERSION}\"")
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)
-target_link_libraries(${PROJECT_NAME} proj Qt5::Network)
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+  proj Qt5::Network
+  angles::angles
+  rclcpp::rclcpp
+  pluginlib::pluginlib
+  rviz_common::rviz_common
+  rviz_default_plugins::rviz_default_plugins
+  ${sensor_msgs_TARGETS}
+)
 
 # prevent pluginlib from using boost
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
@@ -50,7 +59,6 @@ if(BUILD_TESTING)
   target_include_directories(test_field PRIVATE src)
 endif()
 
-ament_target_dependencies(${PROJECT_NAME} SYSTEM angles rclcpp pluginlib rviz_common rviz_default_plugins sensor_msgs)
 ament_export_dependencies(rclcpp pluginlib rviz_common rviz_default_plugins sensor_msgs)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.

Debs are broken https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rviz_satellite__ubuntu_noble_amd64__binary/