### PR TITLE
Use time from msg to support replaying bag

### DIFF
--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -501,7 +501,7 @@ void AerialMapDisplay::update(float, float)
     return;
   }
 
-  auto t = context_->getFrameManager()->getTime();
+  auto t = last_fix_->header.stamp;
 
   Ogre::Vector3 _ignored_translation;
   Ogre::Quaternion orientation_to_map = Ogre::Quaternion::IDENTITY;


### PR DESCRIPTION
It will fail to retrieve the transformation for the sensor frame if we are replaying bag file, as described in
https://github.com/nobleo/rviz_satellite/issues/143 This is caused by the time used to look up sensor frame, which is retrieved via frame_manager->getTime(), i.e., the current ros::time. However, if we are replaying a bag file, only transforms in the past are provided, causing an "extrapolation in the future" error.